### PR TITLE
Replace f-strings with parameter placeholders in database commands

### DIFF
--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -3,6 +3,7 @@ import os
 
 DB_PATH = "config.db"
 
+
 def init_config():
     """makes the configuration database"""
     with sqlite3.connect(DB_PATH) as conn:
@@ -22,41 +23,57 @@ def init_config():
         """)
         conn.commit()
 
+
 def set_guild_config(guild_id, key, value):
     """set a configuration value for a guild"""
     with sqlite3.connect(DB_PATH) as conn:
         c = conn.cursor()
-        c.execute(f"""
-            INSERT INTO guild (guild_id, {key})
+        c.execute(
+            """
+            INSERT INTO guild (guild_id, ?)
             VALUES (?, ?)
-            ON CONFLICT(guild_id) DO UPDATE SET {key} = excluded.{key}
-        """, (str(guild_id), value))
+            ON CONFLICT(guild_id) DO UPDATE SET ? = excluded.?
+        """,
+            key,
+            (str(guild_id), value),
+            key,
+            key,
+        )
         conn.commit()
+
 
 def get_guild_config(guild_id, key):
     """get a configuration value for a guild"""
     with sqlite3.connect(DB_PATH) as conn:
         c = conn.cursor()
-        c.execute(f"SELECT {key} FROM guild WHERE guild_id = ?", (str(guild_id),))
+        c.execute("SELECT ? FROM guild WHERE guild_id = ?", key, (str(guild_id),))
         row = c.fetchone()
         print("getting guild config:", row)
         return row[0] if row else None
+
 
 def set_user_config(user_id, key, value):
     """set a configuration value for a user"""
     with sqlite3.connect(DB_PATH) as conn:
         c = conn.cursor()
-        c.execute(f"""
-            INSERT INTO user (user_id, {key})
+        c.execute(
+            """
+            INSERT INTO user (user_id, ?)
             VALUES (?, ?)
-            ON CONFLICT(user_id) DO UPDATE SET {key} = excluded.{key}
-        """, (str(user_id), value))
+            ON CONFLICT(user_id) DO UPDATE SET ? = excluded.?
+        """,
+            key,
+            (str(user_id), value),
+            key,
+            key,
+        )
         conn.commit()
+
 
 def get_user_config(user_id, key):
     """get a configuration value for a user"""
     with sqlite3.connect(DB_PATH) as conn:
         c = conn.cursor()
-        c.execute(f"SELECT {key} FROM user WHERE user_id = ?", (str(user_id),))
+        c.execute("SELECT ? FROM user WHERE user_id = ?", key, (str(user_id),))
         row = c.fetchone()
         return row[0] if row else None


### PR DESCRIPTION
f-strings in database commands is a security risk (sql injection), and using parameter placeholders instead of f-strings results in cleaner code, lowers the chance of something breaking if something weird is inputted and are handled better. Placeholders are handled by the driver, unlike f-strings which are handled by python.

Unrelated but I'd recommend linting and formatting your code with something like flake8 or Ruff